### PR TITLE
Change public port in DEV

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: BackendDockerfile
     ports:
-      - "8080:8080"
+      - "443:8080"
     volumes:
       - ./data:/app/data  # Map the ./data directory on the host to /app/data in the container
     environment:
@@ -17,7 +17,7 @@ services:
       context: ./chat-langchain
       dockerfile: FrontendDockerfile
     ports:
-      - "3000:3000" # - "3000:80"
+      - "80:3000"
     entrypoint: ["yarn", "dev"]
     environment:
-      - NEXT_PUBLIC_API_BASE_URL=http://3.143.235.233:8080
+      - NEXT_PUBLIC_API_BASE_URL=http://3.143.235.233:443


### PR DESCRIPTION
Since we're currently deploying backend and frontend on the same EC2, and we're asked to only use HTTP (80) and HTTPS (443) ports, I've used 443 for backend and 80 for frontend...

Any better idea for a short term solution?